### PR TITLE
Mirror to Mirror Interaction "Fix"

### DIFF
--- a/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/InteractableMirror.prefab
+++ b/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/InteractableMirror.prefab
@@ -31,14 +31,18 @@ MonoBehaviour:
   ethereal: {fileID: 0}
   real: {fileID: 0}
   rb: {fileID: 0}
-  mass: 1
-  drag: 0
   maxVelocity: 10
   state: 0
   canBecomeEthereal: 0
   xAxis: 1
+  relativeMinX: 0
+  relativeMaxX: 0
   yAxis: 0
+  relativeMinY: 0
+  relativeMaxY: 0
   zAxis: 1
+  relativeMinZ: 0
+  relativeMaxZ: 0
 --- !u!1001 &2039992613240179750
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -61,6 +65,10 @@ PrefabInstance:
     - target: {fileID: 8469968573461780282, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
       propertyPath: m_LocalPosition.z
       value: -74.27999
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469968573461780283, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
+      propertyPath: m_Name
+      value: MirrorCam
       objectReference: {fileID: 0}
     - target: {fileID: 8469968574141035541, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
       propertyPath: m_Name

--- a/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/Mirror.prefab
+++ b/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/Mirror.prefab
@@ -46,7 +46,7 @@ GameObject:
   - component: {fileID: 6869095915292211024}
   - component: {fileID: 8754201930607888752}
   m_Layer: 0
-  m_Name: Camera
+  m_Name: MirrorCam
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/MovingMirror.prefab
+++ b/SelfReflection/SelfReflection/Assets/Prefab/Mirrors/MovingMirror.prefab
@@ -153,6 +153,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.01932722
       objectReference: {fileID: 0}
+    - target: {fileID: 8469968573461780283, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
+      propertyPath: m_Name
+      value: MirrorCam
+      objectReference: {fileID: 0}
     - target: {fileID: 8469968573461780284, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
       propertyPath: field of view
       value: 20.939445

--- a/SelfReflection/SelfReflection/Assets/Scenes/Sandbox/ledge grab test.unity
+++ b/SelfReflection/SelfReflection/Assets/Scenes/Sandbox/ledge grab test.unity
@@ -2755,13 +2755,45 @@ PrefabInstance:
       propertyPath: mainCamera
       value: 
       objectReference: {fileID: 223155936}
+    - target: {fileID: 7621460507839650586, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: field of view
+      value: 36.253468
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650586, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: near clip plane
+      value: 14.847998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650586, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_projectionMatrixMode
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 9.982817
+      value: -9.982817
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.31
       objectReference: {fileID: 0}
     - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 74.32
+      value: -74.27999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8898298
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.08189248
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.44699475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7621460507839650588, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.041137647
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_RootOrder
@@ -2781,7 +2813,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -2789,7 +2821,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalRotation.z
@@ -2801,7 +2833,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7621460509073602609, guid: a5a537c754f773b42bdd4fe8c29ae17f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -2826,7 +2858,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2470032709705241998, guid: ff9b63b97cbb2774b8e7a54e795e3580, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2470032709705242097, guid: ff9b63b97cbb2774b8e7a54e795e3580, type: 3}
       propertyPath: relativeMaxY
@@ -2941,6 +2973,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 180
       objectReference: {fileID: 0}
+    - target: {fileID: 3262416694290508394, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
+      propertyPath: m_Name
+      value: MirrorCam
+      objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508395, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.934999
@@ -2955,27 +2991,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508395, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.15495503
+      value: 0.082526565
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508395, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.051014394
+      value: -0.015290707
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508395, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.93712413
+      value: -0.9797956
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508395, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.30852062
+      value: -0.18153866
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508397, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: field of view
-      value: 69.74225
+      value: 54.93673
       objectReference: {fileID: 0}
     - target: {fileID: 3262416694290508397, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: near clip plane
-      value: 5.4900026
+      value: 11.012003
       objectReference: {fileID: 0}
     - target: {fileID: 6398824764093197809, guid: 37a8ed82142111044ad2cef23a20d0d7, type: 3}
       propertyPath: m_Name

--- a/SelfReflection/SelfReflection/Assets/Scripts/Mirror/GenerateTextureRender.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/Mirror/GenerateTextureRender.cs
@@ -8,6 +8,8 @@ public class GenerateTextureRender : MonoBehaviour
     public Camera cam;
     private RenderTexture rt;
     private Material material;
+    private SetMirroredPosition setMirroredPosition;
+    private Camera selfCamera;
 
     // Start is called before the first frame update
     void Start()
@@ -18,5 +20,19 @@ public class GenerateTextureRender : MonoBehaviour
         cam.targetTexture = rt;
         material.SetTexture("_MainTex", rt);
         GetComponent<Renderer>().material = material;
+
+        setMirroredPosition = transform.parent.GetComponentInChildren<SetMirroredPosition>();
+        selfCamera = transform.parent.GetComponentInChildren<Camera>();
+    }
+
+    private void OnWillRenderObject()
+    {
+        if (Camera.current != null)
+        {
+            if (Camera.current.name != "SceneCamera" && Camera.current.name != "Preview Camera" && Camera.current != selfCamera)
+            {
+                setMirroredPosition.mainCamera = Camera.current;
+            }
+        }
     }
 }


### PR DESCRIPTION
Mirror to mirror interaction is kinda fixed now where mirror's camera are set based on what is rendering it like another mirror camera or the player camera. However the problem with this is it won't work if both mirrors are in player's view and in this case the player camera is prioritized. Essentially I am coping with this method because I can't think of any simpler solutions :^)