### PR TITLE
Implemented Rotation Interaction

### DIFF
--- a/SelfReflection/SelfReflection/Assets/Prefab/InteractableObjects/Cube.prefab
+++ b/SelfReflection/SelfReflection/Assets/Prefab/InteractableObjects/Cube.prefab
@@ -151,6 +151,7 @@ MonoBehaviour:
   interactionState: 0
   isInteractable: 1
   canSwapStates: 1
+  canRotate: 1
   maxVelocity: 15
 --- !u!114 &8609107432906366092
 MonoBehaviour:

--- a/SelfReflection/SelfReflection/Assets/Prefab/InteractableObjects/PlatformingObjects/InteractableBooks/InteractableBookBlue.prefab
+++ b/SelfReflection/SelfReflection/Assets/Prefab/InteractableObjects/PlatformingObjects/InteractableBooks/InteractableBookBlue.prefab
@@ -62,13 +62,17 @@ MonoBehaviour:
   real: {fileID: 0}
   rb: {fileID: 0}
   interactionState: 0
-  isInteractable: 0
+  isInteractable: 1
   canSwapStates: 0
+  canRotate: 0
   maxVelocity: 10
   xAxis: 0
   yAxis: 0
   zAxis: 1
   resetTimer: 10
+  shakeSpeed: 0
+  shakeIntensity: 0
+  speed: 0
 --- !u!54 &5756299006339888878
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/SelfReflection/SelfReflection/Assets/Scenes/Sandbox/object movement test.unity
+++ b/SelfReflection/SelfReflection/Assets/Scenes/Sandbox/object movement test.unity
@@ -216,7 +216,7 @@ Transform:
   m_LocalScale: {x: 40, y: 1, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &196760582
 PrefabInstance:
@@ -235,7 +235,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 442705869615946756, guid: 7e297214005c07849a5296fcad6be033, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 442705869615946756, guid: 7e297214005c07849a5296fcad6be033, type: 3}
       propertyPath: m_LocalScale.x
@@ -312,7 +312,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5756299006339888865, guid: ebf6000b639460644a74c247e44064d6, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5756299006339888865, guid: ebf6000b639460644a74c247e44064d6, type: 3}
       propertyPath: m_LocalScale.x
@@ -383,6 +383,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6671604140988988156, guid: ebf6000b639460644a74c247e44064d6, type: 3}
+      propertyPath: canRotate
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6671604140988988156, guid: ebf6000b639460644a74c247e44064d6, type: 3}
       propertyPath: resetTimer
       value: 30
       objectReference: {fileID: 0}
@@ -417,7 +421,7 @@ PrefabInstance:
       objectReference: {fileID: 1585683374}
     - target: {fileID: 7140929500656145174, guid: 94d8956704e67a84aa728a0c8ed8e4bd, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7140929500656145174, guid: 94d8956704e67a84aa728a0c8ed8e4bd, type: 3}
       propertyPath: m_LocalPosition.x
@@ -567,7 +571,7 @@ Transform:
   m_LocalScale: {x: 40, y: 1, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &632730278
 PrefabInstance:
@@ -578,7 +582,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5756299006339888865, guid: b9d42846f8b2ac74baec510739cb7f82, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5756299006339888865, guid: b9d42846f8b2ac74baec510739cb7f82, type: 3}
       propertyPath: m_LocalScale.x
@@ -659,6 +663,10 @@ PrefabInstance:
     - target: {fileID: 5756299006339888879, guid: b9d42846f8b2ac74baec510739cb7f82, type: 3}
       propertyPath: maxSpeed
       value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5756299006339888879, guid: b9d42846f8b2ac74baec510739cb7f82, type: 3}
+      propertyPath: canRotate
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5756299006339888879, guid: b9d42846f8b2ac74baec510739cb7f82, type: 3}
       propertyPath: maxVelocity
@@ -776,7 +784,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8469968574141035543, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8469968574141035543, guid: e7a85fbac5f92c2469c85bfa17f70ccb, type: 3}
       propertyPath: m_LocalScale.x
@@ -921,7 +929,7 @@ Transform:
   m_LocalScale: {x: 1, y: 25, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1011195053
 PrefabInstance:
@@ -936,7 +944,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8963932246957420790, guid: 21f5216456c2f834d8c19537feda1c11, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8963932246957420790, guid: 21f5216456c2f834d8c19537feda1c11, type: 3}
       propertyPath: m_LocalPosition.x
@@ -997,7 +1005,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 72608089059147460, guid: 1de1cda16f47fe345ab501101898c8bb, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 72608089059147460, guid: 1de1cda16f47fe345ab501101898c8bb, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1382,7 +1390,7 @@ Transform:
   m_LocalScale: {x: 1, y: 25, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1222050735
 GameObject:
@@ -1477,7 +1485,7 @@ Transform:
   m_LocalScale: {x: 1, y: 25, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!20 &1242331341 stripped
 Camera:
@@ -1602,7 +1610,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 2a06a217a822baf43bbc0d4edec5f572, type: 2}
     - target: {fileID: 2987468310820401226, guid: 0988cffd299e6094a83c02b90cf45721, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 2987468310820401226, guid: 0988cffd299e6094a83c02b90cf45721, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1799,8 +1807,65 @@ Transform:
   m_LocalScale: {x: 1, y: 25, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1001 &1826033083
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5407183616095388042, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_Name
+      value: Cube
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.613712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5407183616095388049, guid: fea0100d82098ab459cc427873253f60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fea0100d82098ab459cc427873253f60, type: 3}
 --- !u!1 &2138444104 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7312219954388448228, guid: 1de1cda16f47fe345ab501101898c8bb, type: 3}

--- a/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/Interactable.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/Interactable.cs
@@ -10,6 +10,7 @@ public abstract class Interactable : MonoBehaviour
     public Interaction interactionState;
     public bool isInteractable;
     public bool canSwapStates;
+    public bool canRotate;
     public float maxVelocity;
     protected InteractionController interactionController;
     protected GameObject player;
@@ -70,6 +71,8 @@ public abstract class Interactable : MonoBehaviour
     public abstract void UnSelectObject();
 
     public abstract void MoveObject(float mouseX, float mouseY, float mouseScroll, Vector3 rayDir, Vector3 playerPosition);
+
+    public abstract void Rotate(float mouseX, float mouseY, Vector3 rayDir);
 
     public Vector3 CalculateVelocity(float mouseX, float mouseY, float mouseScroll, Vector3 rayDir, Vector3 playerPosition)
     {

--- a/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractableMirror.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractableMirror.cs
@@ -79,15 +79,18 @@ public class InteractableMirror : Interactable
     public override void SelectObject(InteractionController controller, Interaction interaction)
     {
         interactionController = controller;
-        rb.constraints = RigidbodyConstraints.FreezeRotation;
-        if (controller.relativeMirror == null)
+        switch (interaction)
         {
-            interactionState = Interaction.Holding;
-        }
-        else
-        {
-            rb.drag = 10;
-            interactionState = Interaction.MirrorMove;
+            case Interaction.PickUp:
+            case Interaction.Holding:
+                interactionState = Interaction.Holding;
+                rb.constraints = RigidbodyConstraints.FreezeRotation;
+                break;
+            case Interaction.MirrorMove:
+                interactionState = Interaction.MirrorMove;
+                rb.drag = 10;
+                rb.constraints = RigidbodyConstraints.FreezeRotation;
+                break;
         }
 
         distance = transform.position - controller.transform.position;
@@ -116,5 +119,10 @@ public class InteractableMirror : Interactable
     {
         Vector3 velocity = CalculateVelocity(mouseX, mouseY, mouseScroll, rayDir, playerPosition);
         rb.velocity = Vector3.Lerp(rb.velocity, Vector3.ClampMagnitude(velocity, maxVelocity), 0.3f);
+    }
+
+    public override void Rotate(float mouseX, float mouseY, Vector3 rayDir)
+    {
+        throw new System.NotImplementedException();
     }
 }

--- a/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractableObject.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractableObject.cs
@@ -14,6 +14,7 @@ public class InteractableObject : Interactable
         {
             case Interaction.PickUp:
             case Interaction.Holding:
+            case Interaction.SwapState:
                 interactionState = Interaction.Holding;
                 rb.useGravity = false;
                 rb.constraints = RigidbodyConstraints.FreezeRotation;
@@ -23,6 +24,9 @@ public class InteractableObject : Interactable
                 interactionState = Interaction.MirrorMove;
                 rb.useGravity = false;
                 rb.constraints = RigidbodyConstraints.FreezeRotation;
+                break;
+            case Interaction.Rotate:
+                interactionState = Interaction.Rotate;
                 break;
         }
     }
@@ -70,6 +74,13 @@ public class InteractableObject : Interactable
             SetToEthereal();
             transform.position = mirrorSpawnLocation;
         }
+    }
+
+    public override void Rotate(float mouseX, float mouseY, Vector3 rayDir)
+    {
+        transform.RotateAround(transform.position, Vector3.up, mouseX);
+        Vector3 axis = Vector3.Cross(new Vector3(rayDir.x, 0, rayDir.z), Vector3.up);
+        transform.RotateAround(transform.position, axis, mouseY);
     }
 
     private void OnCollisionEnter(Collision collision)

--- a/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractablePlatform.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/Objects/Interactables/InteractablePlatform.cs
@@ -55,15 +55,19 @@ public class InteractablePlatform : Interactable
     public override void SelectObject(InteractionController controller, Interaction interaction)
     {
         interactionController = controller;
-        interactionState = Interaction.MirrorMove;
-
-        if (!yAxis)
+        switch (interaction)
         {
-            rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
-        }
-        else
-        {
-            rb.constraints = RigidbodyConstraints.FreezeRotation;
+            case Interaction.MirrorMove:
+                interactionState = Interaction.MirrorMove;
+                if (!yAxis)
+                    rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
+                else
+                    rb.constraints = RigidbodyConstraints.FreezeRotation;
+                break;
+            case Interaction.Rotate:
+                interactionState = Interaction.Rotate;
+                rb.constraints = RigidbodyConstraints.FreezePosition;
+                break;
         }
     }
 
@@ -79,6 +83,13 @@ public class InteractablePlatform : Interactable
     {
         Vector3 velocity = CalculateVelocity(mouseX, mouseY, mouseScroll, rayDir, playerPosition);
         rb.velocity = Vector3.Lerp(rb.velocity, Vector3.ClampMagnitude(AdjustVelocity(velocity), maxVelocity), 0.3f);
+    }
+
+    public override void Rotate(float mouseX, float mouseY, Vector3 rayDir)
+    {
+        transform.RotateAround(transform.position, Vector3.up, mouseX);
+        Vector3 axis = Vector3.Cross(new Vector3(rayDir.x, 0, rayDir.z), Vector3.up);
+        transform.RotateAround(transform.position, axis, mouseY);
     }
 
     private Vector3 AdjustVelocity(Vector3 velocity)

--- a/SelfReflection/SelfReflection/Assets/Scripts/PlayerMovement/Camera/PlayerCam.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/PlayerMovement/Camera/PlayerCam.cs
@@ -17,6 +17,8 @@ public class PlayerCam : MonoBehaviour
 
     PlayerMovement playerMovement;
 
+    public bool playerCamLocked;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -28,7 +30,7 @@ public class PlayerCam : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (!playerMovement.movementDisabled)
+        if (!playerMovement.movementDisabled && !playerCamLocked)
         {
             float mouseX = Input.GetAxisRaw("Mouse X") * Time.deltaTime * sensX;
             float mouseY = Input.GetAxisRaw("Mouse Y") * Time.deltaTime * sensY;

--- a/SelfReflection/SelfReflection/Assets/Scripts/UI_Navigation/EnableToolbar.cs
+++ b/SelfReflection/SelfReflection/Assets/Scripts/UI_Navigation/EnableToolbar.cs
@@ -9,7 +9,10 @@ public class EnableToolbar : MonoBehaviour
 
     private void Start()
     {
-        cameraPanning = GameObject.Find("CameraPanningController").GetComponent<CameraPanningController>();
+        if (GameObject.Find("CameraPanningController") != null)
+        {
+            cameraPanning = GameObject.Find("CameraPanningController").GetComponent<CameraPanningController>();
+        }
         toolbar = GameObject.Find("Toolbar").gameObject;
     }
 


### PR DESCRIPTION
Implemented rotate interaction using right click. Right clicking an interactable in a mirror selects it and locks camera. After selection moving mouse up and down rotates interactable on the x-axis relative to the player and moving mouse left and right rotates interactable on the y-axis relative to player.

Interactable prefabs have a new parameter called "Can Rotate" which is a check box to indicate if interactable is able to rotate. Also platforms are also able to rotate, but I don't know whether we will need it so I added the functionality just in case.